### PR TITLE
Add Pomodoro elapsed time

### DIFF
--- a/scripts/pomodoro.sh
+++ b/scripts/pomodoro.sh
@@ -56,20 +56,22 @@ pomodoro_cancel () {
 pomodoro_status () {
     local pomodoro_start_time=$(read_pomodoro_start_time)
     local current_time=$(get_seconds)
-    local difference=$(( ($current_time - $pomodoro_start_time) / 60 ))
+    local difference=$(( ($current_time - $pomodoro_start_time)))
+
+    local remaining= $(( POMODORO_DURATION_MINUTES*60 - $difference ))
 
     if [ $pomodoro_start_time -eq -1 ]
     then
         echo ""
-    elif [ $difference -ge $(( $POMODORO_DURATION_MINUTES + $POMODORO_BREAK_MINUTES )) ]
+    elif [ $difference -ge $(( $POMODORO_DURATION_MINUTES*60 + $POMODORO_BREAK_MINUTES*60 )) ]
     then
         pomodoro_start_time=-1
         echo ""
-    elif [ $difference -ge $POMODORO_DURATION_MINUTES ]
+    elif [ $difference -ge $POMODORO_DURATION_MINUTES*60 ]
     then
         echo "[P:✅] "
     else
-        echo "[P:$(( $POMODORO_DURATION_MINUTES - $difference ))] "
+        printf "Pomodoro Completed: %02d:%02d " $(( difference / 60 )) $(( difference % 60 ))
     fi
 }
 


### PR DESCRIPTION
This replaces the current time to zero counter that only does increments in a resolution of 1 minute with a second by second updating timer.

You can easily modify the default to count down instead of up (perhaps a different commit), but I find this to be more granular and helpful for my Pomodoro sessions.

The status interval for tmux has to be modified in your tmux.conf if you want the status bar to be updated every second instead of however many it takes by default.

Add this line in your config: `set -g status-interval 1`

![image](https://github.com/user-attachments/assets/89f9017d-a3fa-4cee-a1aa-7d3d1cefc8e8)
